### PR TITLE
Changed junos_system examples

### DIFF
--- a/plugins/modules/junos_system.py
+++ b/plugins/modules/junos_system.py
@@ -75,7 +75,7 @@ EXAMPLES = """
     domain-search:
       - ansible.com
       - redhat.com
-      - juniper.com
+      - juniper.net
 
 - name: remove configuration
   junos_system:


### PR DESCRIPTION
Changed "juniper.com" in examples to "juniper.net" which is the proper domain name for Juniper Networks.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Juniper.net is the proper domain name for Juniper Networks.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
