### PR TITLE
Clean up requirements for collection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,6 @@
 ansible
+jxmlease
+ncclient
+paramiko
+scp
+xmltodict

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-black==19.3b0
+black==19.3b0 ; python_version > '3.5'
 flake8
 yamllint

--- a/tests/integration/network-integration.requirements.txt
+++ b/tests/integration/network-integration.requirements.txt
@@ -1,6 +1,0 @@
-pexpect # for _user test
-scp # for Cisco ios
-selectors2 # for ncclient
-ncclient # for Junos
-jxmlease # for Junos
-xmltodict # for Junos


### PR DESCRIPTION
Rather then having ansible-test manage the dependencies, move this is to
top level requirements files.

Depends-On: https://github.com/ansible-collections/netcommon/pull/6
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/366
Signed-off-by: Paul Belanger <pabelanger@redhat.com>