### PR TITLE
Enable basepython=3 for testenvs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,10 @@ envlist = linters
 skipsdist = True
 
 [testenv]
+basepython = python3
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+commands = find {toxinidir} -type f -name "*.py[c|o]" -delete
 
 [testenv:black]
 install_command = pip install {opts} {packages}


### PR DESCRIPTION
As per test-requirements, black is only installed in case of py35 or
greater. In case of environments with several python version (py2/py3)
this leaves black uninstalled, so the tox command for black and linters
totally fails. This commit sorts that out by specifically enabling
python3 for those testenvs.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>